### PR TITLE
Proposal to use Ansible to set up the runners

### DIFF
--- a/CURRENT.md
+++ b/CURRENT.md
@@ -1,0 +1,36 @@
+# Current
+
+**Find IP and log in**
+ssh -L 5900:localhost:5900 -i maplibre-native-ci-runners.pem ec2-user@**Insert public IPv4**
+Example of public IPv4: ec2-34-218-210-7.us-west-2.compute.amazonaws.com
+**Set Password** (otherwise we can’t sudo / screen share)
+sudo passwd ec2-user
+**Install homebrew with**
+/bin/bash -c “$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)”
+## **Install brew packages**
+#### brew install tmux
+#### Install nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+add to .zshrc (following the command prompted by the command above)
+#### brew install ninja
+### Other packages
+* sudo gem install xcpretty
+### Pyenv
+```bash
+brew install pyenv
+```
+pyenv install 3.8.13
+Add to .zshrc:
+```bash
+export PATH=$(pyenv root)/shims:$PATH
+```
+# operating TMUX
+tmux attach-session -t “session name”
+(detach “ctrl-b” and then “d”)
+## **ALLOW SCREEN SHARE**  (apparently necessary to run)
+sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -activate
+**working version of above command**
+`sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -activate -configure -access -off -restart -agent -privs -all -allowAccessFor -allUsers`
+### CHANGE PARTITION DISK HARDDISK SIZE OR OTHER SYSTEM UPDATES
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html#mac-instance-updates
+“Increase the size of an EBS volume on your Mac instance”

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
+# MapLibre CI Runners
 
+This repository contains information about how the CI runners are set up.
+
+## macOS
+
+As of January 6, 2023, the macOS-based CI runners for MapLibre GL Native are set up by hand (see current `./CURRENT.md` for details). Some parts of setting up macOS CI runners are hard to automate fully, most notably installing XCode. However, we will benefit from automation:
+
+- To easily keep the runners in sync without manually applying each change to each server.
+- To be able to document changes.
+- To more easily upgrade to a new macOS version (AWS does not support macOS version upgrades currently, you have to set up a new macOS box).
+
+An infrastructure as code tool called Ansible can help achieve this. You write declarative YAML and Ansible will execute SSH commands to hosts as needed to achieve the desired state. Ansible has the concept of an [inventory](https://docs.ansible.com/ansible/latest//inventory_guide/intro_inventory.html) which is a list of hosts, where each host may belong to a particular group. The inventory is in the file named `inventory`. That is why you need to add the `-i inventory` flag to all commands.
+
+You need to pass a pattern to Ansible that matches one or more hosts to run the command against. For example, you can use the `macos` group.
+
+```
+$ ansible macos --list-hosts -i inventory
+```
+
+You can run an ad-hoc command on all hosts in the `macos` group like so:
+
+```
+$ ansible macos -a '/usr/bin/xcodebuild -version' -i inventory
+```
+
+This should print the installed XCode version for each host. This works because the [command module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html) is used by default (`-m command`) and using `-a <cmd>` you pass the command to it as an argument.
+
+To make changes it is better to record changes in what Ansible calls a [Playbook](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html). Run the `macos.yaml` Playbook as follows:
+
+
+```
+$ ansible-playbook -i inventory macos.yaml
+```
+
+See `requirements.yml` to install the required 'roles'.

--- a/inventory
+++ b/inventory
@@ -1,0 +1,4 @@
+[macos]
+ec2-34-218-210-7.us-west-2.compute.amazonaws.com ansible_user=ec2-user
+ec2-18-236-103-245.us-west-2.compute.amazonaws.com ansible_user=ec2-user
+ec2-3-80-132-4.compute-1.amazonaws.com ansible_user=ec2-user

--- a/macos.yaml
+++ b/macos.yaml
@@ -1,0 +1,33 @@
+---
+- name: Set up macOS CI runner
+  hosts: macos
+  remote_user: ec2-user
+
+  tasks:
+  - name: Install ~/.zshrc
+    ansible.builtin.copy:
+      src: macos/.zshrc
+      dest: ~/.zshrc
+
+  - name: Install ~/.bashrc
+    ansible.builtin.copy:
+      src: macos/.bashrc
+      dest: ~/.bashrc
+
+  - community.general.homebrew:
+      name: ruby
+      state: present
+
+  - name: Install jazzy
+    community.general.gem:
+      name: jazzy
+      user_install: false
+      executable: /opt/homebrew/opt/ruby/bin/gem
+
+  # https://github.com/ffi/ffi/issues/864
+  - name: Install ffi, required for jazzy to function
+    community.general.gem:
+      name: ffi
+      user_install: false
+      build_flags: --enable-libffi-alloc
+      executable: /opt/homebrew/opt/ruby/bin/gem

--- a/macos/.bashrc
+++ b/macos/.bashrc
@@ -1,0 +1,5 @@
+if [ -d "/opt/homebrew/opt/ruby/bin" ]; then
+  export PATH=/opt/homebrew/opt/ruby/bin:$PATH
+  export PATH=`gem environment gemdir`/bin:$PATH
+fi
+

--- a/macos/.zshrc
+++ b/macos/.zshrc
@@ -1,0 +1,29 @@
+# Enable CLI coloring
+export CLICOLOR=1
+
+# For Homebrew
+export HOMEBREW_PREFIX="/opt/homebrew"
+export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
+export HOMEBREW_REPOSITORY="/opt/homebrew"
+export HOMEBREW_SHELLENV_PREFIX="/opt/homebrew"
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin${PATH+:$PATH}"
+export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:"
+export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}"
+
+# The following three checks are in place due to OS updates occasionally resetting the sshd_config file to default.
+# For security, Amazon suggests that password authentication over SSH be disabled.
+if sudo sshd -T | grep -x --quiet "passwordauthentication yes"; then
+  echo "WARNING: Password-based authentication enabled over SSH! This can be insecure and should be disabled in /etc/ssh/sshd_config"
+fi
+
+if sudo sshd -T | grep -x --quiet "challengeresponseauthentication yes"; then
+  echo "WARNING: Challenge Response Authentication enabled over SSH! This can be insecure and should be disabled in /etc/ssh/sshd_config"
+fi
+
+if sudo sshd -T | grep -x --quiet "usepam yes"; then
+  echo "WARNING: Use of Pluggable Authentication Module (PAM) submethod enabled over SSH! This can be insecure and should be disabled in /etc/ssh/sshd_config"
+fi
+
+export NVM_DIR="$HOME/.nvm"
+  [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"  # This loads nvm
+  [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,7 @@
+# install these requirements using:
+# ansible-galaxy install -r requirements.yml
+
+---
+collections:
+- name: community.general
+


### PR DESCRIPTION
Ruby is included by default on macOS, but it won't be for very long anymore and the version is quite old.

I installed Ruby and the jazzy and ffi gems with Homebrew. I set up a `~/.bashrc` such that it picks up the Homebrew ruby and gems before the system ones. It works in a shell (after running `bash`, try `jazzy`) but somehow the CI runner still picks up the system Ruby and gems even though it is also using bash.

In any case, I invite you to try out Ansible with the commands in the README. You need to have a `~/.ssh/config`:

```
Host ec2-34-218-210-7.us-west-2.compute.amazonaws.com ec2-18-236-103-245.us-west-2.compute.amazonaws.com
	IdentityFile ~/cert/maplibre-native-ci-runners.pem

Host ec2-3-80-132-4.compute-1.amazonaws.com
	IdentityFile ~/cert/maplibre-ci-runner-virginia.pem
```