### PR TITLE
Allow querying results by git revision

### DIFF
--- a/mln-lambda/cdk.ts
+++ b/mln-lambda/cdk.ts
@@ -36,6 +36,14 @@ export class AppStack extends Stack {
       }
     );
 
+    resultsTable.addGlobalSecondaryIndex({
+      indexName: 'gitRevision-index',
+      partitionKey: {
+        name: 'gitRevision',
+        type: dynamodb.AttributeType.STRING
+      }
+    });
+
     const lambdaFunction = new NodejsFunction(
       this,
       `${appName}-nodejs-function`,


### PR DESCRIPTION
For example:

https://xsf5g61np6.execute-api.us-west-2.amazonaws.com/prod/results-for-git-rev/afbfd59e2aa3965724237928b2fafe8b325ce38b

Had to add a global secondary index to DynamoDB (one that can be queries without specifying the partitioning key).