### PR TITLE
Install fonts-noto-cjk on ARM runner, update lib-c++, fix deprecated …

### DIFF
--- a/self-hosted/macos.yaml
+++ b/self-hosted/macos.yaml
@@ -13,6 +13,10 @@
       - .bashrc
       - .zshenv
 
+  - name: Tap homebrew/cask-fonts repository, state present
+    community.general.homebrew_tap:
+      name:  homebrew/cask-fonts
+
   - name: Install Homebrew packages
     community.general.homebrew:
       name: "{{ item }}"
@@ -29,6 +33,11 @@
       - pkg-config
       - glfw
       - bazelisk
+
+  - name: Install font-noto-sans-cjk
+    community.general.homebrew_cask:
+      name: font-noto-sans-cjk
+      state: present
 
   - name: Install gems
     community.general.gem:

--- a/self-hosted/ubuntu.yaml
+++ b/self-hosted/ubuntu.yaml
@@ -10,14 +10,14 @@
     github_repo: maplibre-gl-native
     runner_user: ubuntu
   roles:
-    # - role: monolithprojects.github_actions_runner
-    # - role: geerlingguy.nodejs
-    #   vars:
-    #     nodejs_version: "18.x"
-    # - role: geerlingguy.swap
-    #   vars:
-    #     swap_file_size_mb: '2048'
-    # - { role: dockpack.base_cmake, cmake_version: "3.27", cmake_patch_version: "7", cmake_pkg_type: "linux-aarch64" }
+    - role: monolithprojects.github_actions_runner
+    - role: geerlingguy.nodejs
+      vars:
+        nodejs_version: "18.x"
+    - role: geerlingguy.swap
+      vars:
+        swap_file_size_mb: '2048'
+    - { role: dockpack.base_cmake, cmake_version: "3.27", cmake_patch_version: "7", cmake_pkg_type: "linux-aarch64" }
   tasks:
   - name: Install packages
     ansible.builtin.package:

--- a/self-hosted/ubuntu.yaml
+++ b/self-hosted/ubuntu.yaml
@@ -6,18 +6,18 @@
   hosts: ubuntu
   become: yes
   vars:
-    - github_account: maplibre
-    - github_repo: maplibre-gl-native
-    - runner_user: ubuntu
+    github_account: maplibre
+    github_repo: maplibre-gl-native
+    runner_user: ubuntu
   roles:
-    - role: monolithprojects.github_actions_runner
-    - role: geerlingguy.nodejs
-      vars:
-        nodejs_version: "18.x"
-    - role: geerlingguy.swap
-      vars:
-        swap_file_size_mb: '2048'
-    - { role: dockpack.base_cmake, cmake_version: "3.27", cmake_patch_version: "7", cmake_pkg_type: "linux-aarch64" }
+    # - role: monolithprojects.github_actions_runner
+    # - role: geerlingguy.nodejs
+    #   vars:
+    #     nodejs_version: "18.x"
+    # - role: geerlingguy.swap
+    #   vars:
+    #     swap_file_size_mb: '2048'
+    # - { role: dockpack.base_cmake, cmake_version: "3.27", cmake_patch_version: "7", cmake_pkg_type: "linux-aarch64" }
   tasks:
   - name: Install packages
     ansible.builtin.package:
@@ -31,12 +31,13 @@
         - libglfw3-dev
         - libuv1-dev
         - g++-10
-        - libc++-9-dev
-        - libc++abi-9-dev
+        - libc++-11-dev
+        - libc++abi-11-dev
         - ca-certificates
         - wget
         - libjpeg-dev
         - libpng-dev
         - libicu-dev
         - libjpeg-turbo8
+        - fonts-noto-cjk
 


### PR DESCRIPTION
- Install fonts-noto-cjk on ARM runner
- Update lib-c++ (old package no longer available)
- Fix deprecated syntax https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_8.html#deprecated

Needed for https://github.com/maplibre/maplibre-native/pull/1941