### PR TITLE
Edit custom test env benchmark

### DIFF
--- a/aws-device-farm/custom-test-envs/android-benchmark.yaml
+++ b/aws-device-farm/custom-test-envs/android-benchmark.yaml
@@ -19,7 +19,7 @@ phases:
     commands:
       - user_id="$(adb -s $DEVICEFARM_DEVICE_UDID shell dumpsys package org.maplibre.testapp | grep userId | cut -d= -f2)"
       - echo $user_id
-      - adb shell appops set --uid $user_id MANAGE_EXTERNAL_STORAGE allow
+      - adb -s $DEVICEFARM_DEVICE_UDID shell appops set --uid $user_id MANAGE_EXTERNAL_STORAGE allow
       
   # The test phase contains commands for running your tests.
   test:

--- a/aws-device-farm/custom-test-envs/android-benchmark.yaml
+++ b/aws-device-farm/custom-test-envs/android-benchmark.yaml
@@ -17,6 +17,9 @@ phases:
   # The pre-test phase contains commands for setting up your test environment.
   pre_test:
     commands:
+      - user_id="$(adb -s $DEVICEFARM_DEVICE_UDID shell dumpsys package org.maplibre.testapp | grep userId | cut -d= -f2)"
+      - echo $user_id
+      - adb shell appops set --uid $user_id MANAGE_EXTERNAL_STORAGE allow
       
   # The test phase contains commands for running your tests.
   test:
@@ -24,9 +27,8 @@ phases:
       # By default, the following ADB command is used by Device Farm to run your Instrumentation test.
       # Please refer to Android's documentation for more options on running instrumentation tests with adb:
       # https://developer.android.com/studio/test/command-line#run-tests-with-adb
-      - echo "Starting the Instrumentation test"
       - |
-        adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w --no-window-animation \
+        adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w -e package org.maplibre.android.benchmark --no-window-animation \
         $DEVICEFARM_TEST_PACKAGE_NAME/$DEVICEFARM_TEST_PACKAGE_RUNNER 2>&1 || echo \": -1\"" |
         tee $DEVICEFARM_LOG_DIR/instrument.log
       

--- a/aws-device-farm/custom-test-envs/android-ui-test.yaml
+++ b/aws-device-farm/custom-test-envs/android-ui-test.yaml
@@ -26,7 +26,7 @@ phases:
       # https://developer.android.com/studio/test/command-line#run-tests-with-adb
       - echo "Starting the Instrumentation test"
       - |
-        adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w --no-window-animation \
+        adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w -e notClass org.maplibre.android.benchmark.Benchmark --no-window-animation \
         $DEVICEFARM_TEST_PACKAGE_NAME/$DEVICEFARM_TEST_PACKAGE_RUNNER 2>&1 || echo \": -1\"" |
         tee $DEVICEFARM_LOG_DIR/instrument.log
       


### PR DESCRIPTION
Grant the benchmark `MANAGE_EXTERNAL_STORAGE` permissions with

```
adb shell dumpsys package org.maplibre.testapp | grep userId | cut -d= -f2
adb shell appops set --uid $user_id MANAGE_EXTERNAL_STORAGE allow
```