### PR TITLE
Update Android test envs

### DIFF
--- a/aws-device-farm/custom-test-envs/android-benchmark.yaml
+++ b/aws-device-farm/custom-test-envs/android-benchmark.yaml
@@ -27,9 +27,8 @@ phases:
       # By default, the following ADB command is used by Device Farm to run your Instrumentation test.
       # Please refer to Android's documentation for more options on running instrumentation tests with adb:
       # https://developer.android.com/studio/test/command-line#run-tests-with-adb
-      - echo "Starting the Instrumentation test"
       - |
-        adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w -e notClass org.maplibre.android.benchmark.Benchmark --no-window-animation \
+        adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w -e package org.maplibre.android.benchmark --no-window-animation \
         $DEVICEFARM_TEST_PACKAGE_NAME/$DEVICEFARM_TEST_PACKAGE_RUNNER 2>&1 || echo \": -1\"" |
         tee $DEVICEFARM_LOG_DIR/instrument.log
       


### PR DESCRIPTION
The app id changed so the custom test env needs to be updated.

https://developer.android.com/training/data-storage/manage-all-files#enable-manage-external-storage-for-testing

I already updated it, just committing them here for documentation purposes.